### PR TITLE
Wire-up slider

### DIFF
--- a/app.cabal
+++ b/app.cabal
@@ -22,6 +22,8 @@ common wasm
       -no-hs-main -optl-mexec-model=reactor "-optl-Wl,--export=hs_start"
     cpp-options:
       -DWASM
+    build-depends:
+      jsaddle-wasm >= 0.1.2 && < 0.2
 
 common js
   if arch(javascript)
@@ -35,6 +37,8 @@ executable app
     Main.hs
   build-depends:
     base < 5, miso, miso-ui, jsaddle
+  js-sources:
+    js/util.js
   hs-source-dirs:
     app, app/pages
   other-modules:
@@ -43,6 +47,7 @@ executable app
     KitchenSink
     Accordion
     Alert
+    Types
   default-language:
     Haskell2010
 

--- a/app/pages/KitchenSink.hs
+++ b/app/pages/KitchenSink.hs
@@ -5240,7 +5240,7 @@ kitchenSinkPage = div_
                                     ]
                                 , onCreatedWith InitSlider
                                 , onBeforeDestroyedWith DestroySlider
-                                , step_ "50"
+                                , step_ "1"
                                 , value_ "150"
                                 , max_ "200"
                                 , min_ "0"

--- a/app/pages/KitchenSink.hs
+++ b/app/pages/KitchenSink.hs
@@ -9,10 +9,12 @@ import           Miso.Html.Property hiding (max_, min_, label_, form_)
 import           Miso.Svg.Element
 import           Miso.Svg.Property hiding (id_, height_, width_, path_)
 
+import           Types
+
 focusable_ :: MisoString -> Attribute action
 focusable_ = textProp "focusable"
 
-kitchenSinkPage :: View model action
+kitchenSinkPage :: View model Action
 kitchenSinkPage = div_
     []
     [ div_
@@ -5234,9 +5236,13 @@ kitchenSinkPage = div_
                             [class_ "max-w-sm"]
                             [ input_
                                 [ CSS.style_
-                                    ["--slider-value" =: "44.44444444444444%"]
-                                , value_ "12"
-                                , max_ "27"
+                                    [ "--slider-value" =: "75%"
+                                    ]
+                                , onCreatedWith InitSlider
+                                , onBeforeDestroyedWith DestroySlider
+                                , step_ "50"
+                                , value_ "150"
+                                , max_ "200"
                                 , min_ "0"
                                 , class_ "input w-full"
                                 , type_ "range"

--- a/app/pages/Types.hs
+++ b/app/pages/Types.hs
@@ -1,0 +1,33 @@
+-----------------------------------------------------------------------------
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
+-----------------------------------------------------------------------------
+module Types where
+-----------------------------------------------------------------------------
+import Miso
+import Miso.Router
+-----------------------------------------------------------------------------
+import GHC.Generics
+-----------------------------------------------------------------------------
+data Action
+  = ToggleDarkMode PointerEvent
+  | ChangeTheme MisoString
+  | ToggleSidebar PointerEvent
+  | GetURI URI
+  | InitSlider DOMRef
+  | DestroySlider DOMRef
+  | GoTo Page
+-----------------------------------------------------------------------------
+data Model
+  = Model
+  { _currentPage :: Page
+  } deriving Eq
+-----------------------------------------------------------------------------
+data Page = Index
+  deriving stock (Show, Eq, Generic)
+  deriving anyclass (Router)
+-----------------------------------------------------------------------------
+emptyModel :: Model
+emptyModel = Model Index
+-----------------------------------------------------------------------------

--- a/cabal.project
+++ b/cabal.project
@@ -7,6 +7,6 @@ allow-newer:
 source-repository-package
   type: git
   location: https://github.com/dmjio/miso
-  tag: 1ffe48c3f4e4e1dd2b91af0925b85512f26eec84
+  tag: 4a8cba1a1b5a9a25cb0eebbd9c1f792544ec6bba
 
 flags: +template-haskell

--- a/flake.lock
+++ b/flake.lock
@@ -584,11 +584,11 @@
         "servant": "servant"
       },
       "locked": {
-        "lastModified": 1764006838,
-        "narHash": "sha256-milel2aTPRkU9XYq7futekeju3sHRPH1sRMJQGswD7c=",
+        "lastModified": 1764092010,
+        "narHash": "sha256-CBfIrVCnXUdI8LUidYVJtN8FWovHs/dOXj/00gzqhHo=",
         "owner": "dmjio",
         "repo": "miso",
-        "rev": "1ffe48c3f4e4e1dd2b91af0925b85512f26eec84",
+        "rev": "4a8cba1a1b5a9a25cb0eebbd9c1f792544ec6bba",
         "type": "github"
       },
       "original": {

--- a/js/util.js
+++ b/js/util.js
@@ -1,11 +1,24 @@
 /* slider helpers */
-function updateSlider (slider) {
+function updateSlider(slider) {
   const min = parseFloat(slider.min || 0);
   const max = parseFloat(slider.max || 100);
-  const value = parseFloat(slider.value);
+  const step = parseFloat(slider.step || 1);
+
+  // Get the raw value and adjust it to the nearest valid step
+  const rawValue = parseFloat(slider.value);
+  const steppedValue = Math.round((rawValue - min) / step) * step + min;
+
+  // Ensure the value is within min/max bounds and applies the step
+  const value = Math.max(min, Math.min(max, steppedValue));
+
+  // Update the actual slider value to the stepped value
+  if (value !== rawValue) {
+    slider.value = value;
+  }
+
   const percent = (max === min) ? 0 : ((value - min) / (max - min)) * 100;
   slider.style.setProperty('--slider-value', `${percent}%`);
-};
+}
 
 globalThis.initSlider = function (slider) {
   updateSlider(slider);

--- a/js/util.js
+++ b/js/util.js
@@ -1,0 +1,21 @@
+/* slider helpers */
+function updateSlider (slider) {
+  const min = parseFloat(slider.min || 0);
+  const max = parseFloat(slider.max || 100);
+  const value = parseFloat(slider.value);
+  const percent = (max === min) ? 0 : ((value - min) / (max - min)) * 100;
+  slider.style.setProperty('--slider-value', `${percent}%`);
+};
+
+globalThis.initSlider = function (slider) {
+  updateSlider(slider);
+  slider.addEventListener('input', function (event) {
+   updateSlider(event.target)
+  });
+}
+
+globalThis.deinitSlider = function (slider) {
+  slider.removEventListener('input', function (event) {
+    updateSlider(event.target)
+  });
+}


### PR DESCRIPTION
Uses `onBeforeDestroyedWith` / `onCreatedWith` node lifecycle hooks to add / remove a custom even listener for the slider.