### PR TITLE
Use `prerender` / `hydration` for `miso-ui`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY= update build optim
 
-all: update build optim
+all: update build optim prerender
 
 js: update-js build-js
 

--- a/client/Main.hs
+++ b/client/Main.hs
@@ -35,7 +35,7 @@ withJS action = void $ do
   action
 -----------------------------------------------------------------------------
 main :: IO ()
-main = withJS $ startApp defaultEvents app { logLevel = DebugAll }
+main = withJS $ prerender defaultEvents app { logLevel = DebugAll }
 #ifdef VANILLA
   { styles =
       [ Href "/assets/styles.css"

--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1771521367,
-        "narHash": "sha256-GSJCveJNDhhkI303w6udYSu1TWL11AAcWQ0qB+7zTSE=",
+        "lastModified": 1771684689,
+        "narHash": "sha256-BnuJcYK+ZU3DfKvtBs3roq9ek+NWUnBELWHKjJoooeI=",
         "owner": "dmjio",
         "repo": "miso",
-        "rev": "d8242ef052010aaea9150b2f96b6ba7342712b1f",
+        "rev": "8017bd4fa957a6a354ae42c8f85af33e9e449864",
         "type": "github"
       },
       "original": {

--- a/lib/Miso/UI/Tabs.hs
+++ b/lib/Miso/UI/Tabs.hs
@@ -86,10 +86,10 @@ tab_ attrs kids =
     True
     [ -- P.aria_ "selected" "true"
       -- SP.tabindex_ "-1"
-      P.aria_ "labelledby" "demo-tabs-with-panels-tab-1"
-    , P.id_ "demo-tabs-with-panels-panel-1"
+--      P.aria_ "labelledby" "demo-tabs-with-panels-tab-1"
+--    , P.id_ "demo-tabs-with-panels-panel-1"
       -- dmj: these must match tabButton_ "controls"
-    , P.role_ "tabpanel"
+     P.role_ "tabpanel"
     ]
     kids
 -----------------------------------------------------------------------------

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -145,11 +145,6 @@ indexHtml =
            });
       })();
       """
-    , script_ [ type_ "module" ] """
-        import hljs from '@highlightjs/cdn-assets/es/core.js';
-        import javascript from '@highlightjs/cdn-assets/es/languages/haskell.min.js';
-        hljs.registerLanguage('haskell', haskell);
-      """
     , style_ [] """
         body {
           overflow-x: hidden;


### PR DESCRIPTION
Fix bug where `id_` was specified twice.

- [x] Use `prerender` function